### PR TITLE
Temporarily disable user whitelist check

### DIFF
--- a/backend/danswer/auth/users.py
+++ b/backend/danswer/auth/users.py
@@ -167,7 +167,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> models.UOAP:
-        verify_email_in_whitelist(account_email)
         verify_email_domain(account_email)
 
         return await super().oauth_callback(  # type: ignore


### PR DESCRIPTION
New Users Management logic seems to cause broken Oauth login, so temporarily disable it to debug the issue.

Signed-off-by: Alex Co <alex.tuan@mindvalley.com>
